### PR TITLE
Weekly workflow to build and publish to store

### DIFF
--- a/.github/workflows/build-and-publish-snap.yml
+++ b/.github/workflows/build-and-publish-snap.yml
@@ -1,0 +1,93 @@
+name: Build and test snap
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  # Allow manual trigger
+  workflow_dispatch:
+
+env:
+  ARTIFACT_AMD64: matter-all-clusters-app_${{ github.run_number}}_amd64
+  ARTIFACT_ARM64: matter-all-clusters-app_${{ github.run_number}}_arm64
+
+jobs:
+  build-amd64:
+    outputs:
+      snap: ${{ steps.snapcraft.outputs.snap }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: snapcraft
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_AMD64 }}
+          path: ${{ steps.snapcraft.outputs.snap }}
+          if-no-files-found: error
+
+  publish-amd64:
+    needs: build-amd64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download locally built snap
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_AMD64 }}
+
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: ${{ needs.build-amd64.outputs.snap }}
+          release: edge/ieng-1031
+
+  build-arm64:
+    # We do not start the long running arm64 build unless the amd64 build has passed.
+    needs: build-amd64
+    outputs:
+      snap: ${{ steps.snapcraft.outputs.snap }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Build snap
+        uses: diddlesnaps/snapcraft-multiarch-action@v1
+        id: snapcraft
+        with:
+          architecture: arm64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_ARM64 }}
+          path: ${{ steps.snapcraft.outputs.snap }}
+
+  publish-arm64:
+    needs: [build-arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download locally built snap
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_ARM64 }}
+
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: ${{ needs.build-arm64.outputs.snap }}
+          release: edge/ieng-1031
+

--- a/.github/workflows/build-and-publish-snap.yml
+++ b/.github/workflows/build-and-publish-snap.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   build-amd64:
+    if: github.ref == 'refs/heads/main'
     outputs:
       snap: ${{ steps.snapcraft.outputs.snap }}
     runs-on: ubuntu-latest
@@ -35,6 +36,7 @@ jobs:
           if-no-files-found: error
 
   publish-amd64:
+    if: github.ref == 'refs/heads/main'
     needs: build-amd64
     runs-on: ubuntu-latest
     steps:
@@ -48,7 +50,7 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
           snap: ${{ needs.build-amd64.outputs.snap }}
-          release: edge/feature/ieng-1031_test&very
+          release: latest/edge
 
   build-arm64:
     # We do not start the long running arm64 build unless the amd64 build has passed.
@@ -78,6 +80,7 @@ jobs:
           path: ${{ steps.snapcraft.outputs.snap }}
 
   publish-arm64:
+    if: github.ref == 'refs/heads/main'
     needs: [build-arm64]
     runs-on: ubuntu-latest
     steps:
@@ -91,5 +94,5 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
           snap: ${{ needs.build-arm64.outputs.snap }}
-          release: edge/ieng-1031
+          release: latest/edge
 

--- a/.github/workflows/build-and-publish-snap.yml
+++ b/.github/workflows/build-and-publish-snap.yml
@@ -1,6 +1,8 @@
-name: Build and test snap
+name: Build and publish snap
 
 on:
+  schedule:
+    - cron: "20 2 * * 1"  # Monday morning 02:20 UTC
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/build-and-publish-snap.yml
+++ b/.github/workflows/build-and-publish-snap.yml
@@ -48,7 +48,7 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
           snap: ${{ needs.build-amd64.outputs.snap }}
-          release: edge/ieng-1031
+          release: edge/feature/ieng-1031_test&very
 
   build-arm64:
     # We do not start the long running arm64 build unless the amd64 build has passed.

--- a/.github/workflows/build-and-publish-snap.yml
+++ b/.github/workflows/build-and-publish-snap.yml
@@ -16,7 +16,6 @@ env:
 
 jobs:
   build-amd64:
-    if: github.ref == 'refs/heads/main'
     outputs:
       snap: ${{ steps.snapcraft.outputs.snap }}
     runs-on: ubuntu-latest
@@ -36,6 +35,7 @@ jobs:
           if-no-files-found: error
 
   publish-amd64:
+    # Only publish if we are on the main branch
     if: github.ref == 'refs/heads/main'
     needs: build-amd64
     runs-on: ubuntu-latest
@@ -80,6 +80,7 @@ jobs:
           path: ${{ steps.snapcraft.outputs.snap }}
 
   publish-arm64:
+    # Only publish if we are on the main branch
     if: github.ref == 'refs/heads/main'
     needs: [build-arm64]
     runs-on: ubuntu-latest

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,8 @@ layout:
 parts:  
   all-clusters:
     plugin: nil
+    build-environment:
+      - PACKAGE_VERSION: snap
     source: https://github.com/project-chip/connectedhomeip.git
     source-depth: 1
     source-tag: master
@@ -41,9 +43,9 @@ parts:
       # Shallow clone the submodules
       scripts/checkout_submodules.py --shallow --platform linux
 
-      # Set the snap version
-      SHORT_HASH=$(git rev-parse --short HEAD)
-      craftctl set version=$SHORT_HASH+snap
+      # prefix the snap version with the upstream tag, or fall back to the commit hash
+      UPSTREAM_VERSION=$(git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD)
+      craftctl set version=$UPSTREAM_VERSION+$PACKAGE_VERSION
 
     override-build: |
       # The project writes its data to /tmp which isn't persisted.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,7 +32,7 @@ parts:
   all-clusters:
     plugin: nil
     build-environment:
-      - PACKAGE_VERSION: snap
+      - BUILD_METADATA: snap
     source: https://github.com/project-chip/connectedhomeip.git
     source-depth: 1
     source-tag: master
@@ -45,7 +45,7 @@ parts:
 
       # prefix the snap version with the upstream tag, or fall back to the commit hash
       UPSTREAM_VERSION=$(git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD)
-      craftctl set version=$UPSTREAM_VERSION+$PACKAGE_VERSION
+      craftctl set version=$UPSTREAM_VERSION+$BUILD_METADATA
 
     override-build: |
       # The project writes its data to /tmp which isn't persisted.


### PR DESCRIPTION
Add a workflow that does a weekly build of the main branch and publish the snap to the snapcraft store. This workflow is also triggered on pushing to the main branch.

The version number of the snap is brought into line with chip-tool, using the upstream tag or commit hash, along with a build metadata field for the snap package version.