### PR TITLE
Update base to core24

### DIFF
--- a/.github/workflows/snap-ci.yml
+++ b/.github/workflows/snap-ci.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         runs:
           - architecture: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - architecture: arm64
-            runner: [self-hosted, ARM64, Linux]
+            runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs.runner }}
 
     steps:

--- a/.github/workflows/snap-ci.yml
+++ b/.github/workflows/snap-ci.yml
@@ -9,6 +9,11 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+# Keep one CICD run active at a time so publish/test/promote happen in order
+concurrency:
+  group: ${{ github.workflow }}
+  queue: max
+
 env:
   SNAP_NAME: matter-all-clusters-app
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -91,6 +91,13 @@ parts:
       - libcairo2-dev
       - libreadline-dev
       - generate-ninja
+      - libevent-dev
+
+  runtime-dependencies:
+    plugin: nil
+    stage-packages:
+      - libevent-core-2.1-7t64
+      - libevent-pthreads-2.1-7t64
 
   local-bin:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,10 +10,10 @@ license: Apache-2.0
 grade: stable
 confinement: strict
 
-base: core22
-architectures:
-  - build-on: amd64
-  - build-on: arm64
+base: core24
+platforms:
+  amd64:
+  arm64:
 
 
 plugs:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,7 @@
 # Run tests
 
 ```bash
-go test -v -failfast -count 1
+SNAP_PATH=/path/to/chip-tool.snap go test -v -failfast -count 1
 ```
 
 where:
@@ -24,6 +24,7 @@ For building and flashing RCP firmware, please refer
 to [Build and flash RCP firmware on nRF52480 dongle](https://github.com/canonical/openthread-border-router-snap/wiki/Setup-OpenThread-Border-Router-with-nRF52840-Dongle#build-and-flash-rcp-firmware-on-nrf52480-dongle).
 
 ```bash
+SNAP_CHANNEL="latest/candidate" \
 LOCAL_INFRA_IF="eno1" \
 REMOTE_INFRA_IF="eth0" \
 REMOTE_USER="ubuntu" \

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,7 @@
 # Run tests
 
 ```bash
-SNAP_PATH=/path/to/chip-tool.snap go test -v -failfast -count 1
+SNAP_PATH=/path/to/matter-all-clusters-app.snap go test -v -failfast -count 1
 ```
 
 where:


### PR DESCRIPTION
## Summary
<!-- PR description, link to related documents and PRs -->

* Upgrade snap base to core24. Builds started failing due to a dependency that requires a newer Python version. Upgrading the base solves this issue.
* Use github hosted runners, also for arm64
* Add a missing dependency libevent, which was introduced in https://github.com/project-chip/connectedhomeip/pull/42578
* Small changes to testing readme to help running tests quicker

Similar to https://github.com/canonical/chip-tool-snap/pull/99

## Related issues
<!-- Add issues in bullets. Use Github keywords to link the PR to issues -->

## Testing steps
<!-- Steps to test the changes -->

<!-- Reminders:
 - Remove empty sections
 - Increment the version
 - Add/update tests
 - Update CI/CD pipelines
 - Update README(s)
 - Update external docs
-->
